### PR TITLE
fix: Proxy implementation ownership

### DIFF
--- a/contracts/MixinOperatorResolver.sol
+++ b/contracts/MixinOperatorResolver.sol
@@ -14,7 +14,7 @@ abstract contract MixinOperatorResolver {
     event CacheUpdated(bytes32 name, IOperatorResolver.Operator destination);
 
     /// @dev The OperatorResolver used to build the cache
-    OperatorResolver public resolver;
+    OperatorResolver public immutable resolver;
 
     /// @dev Cache operators map of the name and address
     mapping(bytes32 => IOperatorResolver.Operator) private addressCache;

--- a/contracts/NestedFactory.sol
+++ b/contracts/NestedFactory.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.11;
 
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "./abstracts/OwnableProxyDelegation.sol";
 import "./libraries/ExchangeHelpers.sol";
 import "./interfaces/external/IWETH.sol";
 import "./interfaces/INestedFactory.sol";
@@ -15,7 +15,7 @@ import "./NestedRecords.sol";
 
 /// @title Creates, updates and destroys NestedAssets (portfolios).
 /// @notice Responsible for the business logic of the protocol and interaction with operators
-contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperatorResolver {
+contract NestedFactory is INestedFactory, ReentrancyGuard, OwnableProxyDelegation, MixinOperatorResolver {
     using SafeERC20 for IERC20;
     address private constant ETH = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 

--- a/contracts/abstracts/OwnableProxyDelegation.sol
+++ b/contracts/abstracts/OwnableProxyDelegation.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.11;
+
+import "@openzeppelin/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/utils/StorageSlot.sol";
+
+/// @notice Ownable re-implementation to initialize the owner in the
+///         proxy storage after an "upgradeToAndCall()` (delegatecall).
+/// @dev The implementation contract owner will be address zero (by removing the constructor)
+abstract contract OwnableProxyDelegation is Context {
+    /// @dev The contract owner 
+    address private _owner;
+
+    /// @dev Storage slot with the proxy admin
+    bytes32 internal constant _ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+
+    /// @dev True if the owner is setted
+    bool public initialized;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /// @notice Initialize the owner
+    /// @param ownerAddr The owner address
+    function initialize(address ownerAddr) external {
+        require(!initialized, "OFP: INITIALIZED");
+        require(StorageSlot.getAddressSlot(_ADMIN_SLOT).value == msg.sender, "OFP: FORBIDDEN");
+
+        _setOwner(ownerAddr);
+
+        initialized = true;
+    }
+
+    /// @dev Returns the address of the current owner.
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /// @dev Throws if called by any account other than the owner.
+    modifier onlyOwner() {
+        require(owner() == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /// @dev Leaves the contract without owner. It will not be possible to call
+    /// `onlyOwner` functions anymore. Can only be called by the current owner.
+    /// 
+    /// NOTE: Renouncing ownership will leave the contract without an owner,
+    /// thereby removing any functionality that is only available to the owner.
+    function renounceOwnership() public virtual onlyOwner {
+        _setOwner(address(0));
+    }
+
+    /// @dev Transfers ownership of the contract to a new account (`newOwner`).
+    /// Can only be called by the current owner.
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        _setOwner(newOwner);
+    }
+
+    function _setOwner(address newOwner) private {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+}

--- a/scripts/deployAllWithoutProxy.ts
+++ b/scripts/deployAllWithoutProxy.ts
@@ -69,7 +69,7 @@ async function main(): Promise<void> {
     console.log("ZeroExOperator deployed : ", zeroExOperator.address);
 
     // Add ZeroExStorage address
-    deployments.push({name: "ZeroExStorage", address: await zeroExOperator.storageAddress(zeroExOperator.address)})
+    deployments.push({name: "ZeroExStorage", address: await zeroExOperator.operatorStorage()})
 
     // Deploy FlatOperator
     const flatOperator = await flatOperatorFactory.deploy();

--- a/scripts/transferOwnershipToTimelock.ts
+++ b/scripts/transferOwnershipToTimelock.ts
@@ -21,7 +21,7 @@ async function main(): Promise<void> {
     const nestedRecords = await nestedRecordsFactory.attach(context[chainId].NestedRecords);
     const operatorResolver = await operatorResolverFactory.attach(context[chainId].OperatorResolver);
     const zeroExOperator = await zeroExOperatorFactory.attach(context[chainId].ZeroExOperator);
-    const storageAddress = await zeroExOperator.storageAddress(zeroExOperator.address);
+    const storageAddress = await zeroExOperator.operatorStorage();
     const zeroExStorage = await zeroExStorageFactory.attach(storageAddress);
     const nestedFactory = await nestedFactoryFactory.attach(context[chainId].NestedFactory);
     const nestedReserve = await nestedReserveFactory.attach(context[chainId].NestedReserve);

--- a/test/shared/actors.ts
+++ b/test/shared/actors.ts
@@ -9,6 +9,7 @@ export const WALLET_USER_INDEXES = {
     MASTER_DEPLOYER: 5,
     SHAREHOLDER_1: 6,
     SHAREHOLDER_2: 7,
+    PROXY_ADMIN: 8,
 };
 
 export class ActorFixture {
@@ -51,6 +52,10 @@ export class ActorFixture {
 
     shareHolder2() {
         return this._getActor(WALLET_USER_INDEXES.SHAREHOLDER_2);
+    }
+
+    proxyAdmin() {
+        return this._getActor(WALLET_USER_INDEXES.PROXY_ADMIN);
     }
 
     private _getActor(index: number): Wallet {

--- a/test/unit/NestedFactory.unit.ts
+++ b/test/unit/NestedFactory.unit.ts
@@ -4,7 +4,7 @@ import { createFixtureLoader, expect, provider } from "../shared/provider";
 import { BigNumber, BigNumberish, BytesLike, Wallet } from "ethers";
 import { appendDecimals, BIG_NUMBER_ZERO, getExpectedFees, toBytes32 } from "../helpers";
 import { ethers, network } from "hardhat";
-import { importOperators } from '../../scripts/utils';
+import { importOperatorsWithSigner } from '../../scripts/utils';
 
 let loadFixture: LoadFixtureFunction;
 
@@ -111,6 +111,7 @@ describe("NestedFactory", () => {
 
             // Must have 2 operators ("ZeroEx" from Fixture and "test")
             expect(operators.length).to.be.equal(3);
+            console.log(operators[0], operators[1], operators[2]);
             expect(operators[0]).to.be.equal(context.zeroExOperatorNameBytes32);
             expect(operators[1]).to.be.equal(context.flatOperatorNameBytes32);
             expect(operators[2]).to.be.equal(toBytes32("test"));
@@ -128,23 +129,25 @@ describe("NestedFactory", () => {
             const operatorResolver = await context.operatorResolver
                 .connect(context.masterDeployer);
             // Add the operator named "test"
-            await importOperators(operatorResolver,
+            await importOperatorsWithSigner(operatorResolver,
                 [{
                     name: 'test',
                     contract: testAddress,
                     signature: 'function test()',
                 }],
                 context.nestedFactory,
+                context.masterDeployer
             );
 
             // Then remove the operator
-            await importOperators(operatorResolver,
+            await importOperatorsWithSigner(operatorResolver,
                 [{
                     name: "test",
                     contract: ethers.constants.AddressZero,
                     signature: "function test()",
                 }],
                 null,
+                context.masterDeployer
             );
             await context.nestedFactory.connect(context.masterDeployer).rebuildCache();
             await context.nestedFactory.connect(context.masterDeployer).removeOperator(toBytes32("test"));


### PR DESCRIPTION
_Context: Allow storing the owner of `NestedFactory` in the `TransparentUpgradeableProxy` storage._

Added a re-implementation of the OpenZeppelin `Ownable` contract with some changes : 
- Removed the constructor, so the deployer is not the owner (but address zero).
- The owner can be initialized through the proxy (storage) by calling `initialize` using the proxy function `upgradeToAndCall()`. Only the admin at `bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1))` storage slot can `delegatecall` this function and only once.

**The idea is to let the proxy admin set the owner (in the proxy storage/context) after deploying the implementation and proxy. Then the initialized owner can add the operators for example.**

Here is the new process: 

- Deploy `NestedFactory` => `_owner` is address zero (because the constructor is removed in `OwnableProxyDelegation`)
- Deploy `TransparentUpgradeableProxy`, set `NestedFactory` as implementation and deployer as `admin`. 
**Note :** We are forced to set an implementation to deploy the proxy, otherwise we need to create a custom proxy.
- Call proxy function `upgradeToAndCall()` with the `NestedFactory` address and the `initialize(deployer)` calldata. We are sending a second time the `NestedFactory` as the implementation, but there are no side effects. The deployer is now the owner of the `NestedFactory` through the proxy.