### PR TITLE
test: repair `solidity-coverage`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "prettier-plugin-solidity": "^1.0.0-beta.18",
         "solhint": "^3.3.4",
         "solhint-plugin-prettier": "^0.0.5",
-        "solidity-coverage": "^0.7.16",
+        "solidity-coverage": "0.7.18",
         "synthetix": "^2.50.0-ovm-alpha",
         "ts-node": "^9.1.1",
         "typechain": "^5.1.2",

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -24,6 +24,7 @@ export type OperatorResolverFixture = { operatorResolver: OperatorResolver };
 
 export const operatorResolverFixture: Fixture<OperatorResolverFixture> = async (wallets, provider) => {
     const signer = new ActorFixture(wallets as Wallet[], provider).addressResolverOwner();
+    await network.provider.send("hardhat_setBalance", [signer.address, appendDecimals(100000000000000000).toHexString()]);
 
     const operatorResolverFactory = await ethers.getContractFactory("OperatorResolver");
     const operatorResolver = await operatorResolverFactory.connect(signer).deploy();
@@ -185,6 +186,10 @@ export const factoryAndOperatorsFixture: Fixture<FactoryAndOperatorsFixture> = a
     // Get the user1 actor
     const user1 = new ActorFixture(wallets as Wallet[], provider).user1();
 
+    // add ether to wallets
+    await network.provider.send("hardhat_setBalance", [masterDeployer.address, appendDecimals(100000000000000000).toHexString()]);
+    await network.provider.send("hardhat_setBalance", [user1.address, appendDecimals(100000000000000000).toHexString()]);
+
     // Set factory to asset, records and reserve
     await nestedAsset.connect(masterDeployer).addFactory(nestedFactory.address);
     await nestedRecords.connect(masterDeployer).addFactory(nestedFactory.address);
@@ -210,7 +215,6 @@ export const factoryAndOperatorsFixture: Fixture<FactoryAndOperatorsFixture> = a
     const baseAmount = appendDecimals(1000);
 
     // Send funds to User and router
-    await network.provider.send("hardhat_setBalance", [user1.address, baseAmount.toHexString()]);
     await mockUNI.connect(masterDeployer).transfer(dummyRouter.address, baseAmount);
     await mockKNC.connect(masterDeployer).transfer(dummyRouter.address, baseAmount);
     await mockDAI.connect(masterDeployer).transfer(dummyRouter.address, baseAmount);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5132,7 +5132,7 @@ functional-red-black-tree@^1.0.1, functional-red-black-tree@~1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-ganache-cli@^6.11.0:
+ganache-cli@^6.12.2:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.12.2.tgz#c0920f7db0d4ac062ffe2375cb004089806f627a"
   integrity sha512-bnmwnJDBDsOWBUP8E/BExWf85TsdDEFelQSzihSJm9VChVO1SHp94YXLP5BlA4j/OTxp0wR4R1Tje9OHOuAJVw==
@@ -9151,18 +9151,18 @@ solidity-comments-extractor@^0.0.7:
   resolved "https://registry.yarnpkg.com/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz#99d8f1361438f84019795d928b931f4e5c39ca19"
   integrity sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==
 
-solidity-coverage@^0.7.16:
-  version "0.7.16"
-  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.7.16.tgz#c8c8c46baa361e2817bbf275116ddd2ec90a55fb"
-  integrity sha512-ttBOStywE6ZOTJmmABSg4b8pwwZfYKG8zxu40Nz+sRF5bQX7JULXWj/XbX0KXps3Fsp8CJXg8P29rH3W54ipxw==
+solidity-coverage@0.7.18:
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.7.18.tgz#3dac9e0bf97aadf028d989dacdc3159c7879d9c0"
+  integrity sha512-H1UhB9QqLISJPgttaulnStUyOaJm0wZXvBGWUN9+HH3dl2hYjSmo3RBBFRm7U+dBNpPysS835XFGe+hG4ZhMrA==
   dependencies:
-    "@solidity-parser/parser" "^0.12.0"
+    "@solidity-parser/parser" "^0.13.2"
     "@truffle/provider" "^0.2.24"
     chalk "^2.4.2"
     death "^1.1.0"
     detect-port "^1.3.0"
     fs-extra "^8.1.0"
-    ganache-cli "^6.11.0"
+    ganache-cli "^6.12.2"
     ghost-testrpc "^0.0.2"
     global-modules "^2.0.0"
     globby "^10.0.1"


### PR DESCRIPTION
The hardhat plugin `solidity-coverage` wasn't working :
 
- Upgrade `solidity-coverage`
- Add more Ether to signers balance (since the plugin seems to run the tests with higher gasLimit)

📄 [Download the coverage report](https://github.com/NestedFinance/nested-core-lego/files/7932516/coverage.zip)
 
Current state of the test coverage on `master` : 
![image](https://user-images.githubusercontent.com/22816913/150954845-269ae383-0a56-40a3-a78a-c8fece56418b.png)
![image](https://user-images.githubusercontent.com/22816913/150955078-d9e20f4f-dda4-4c6f-b007-2528623a14d4.png)
![image](https://user-images.githubusercontent.com/22816913/150955124-547c76c6-c12b-4064-ae74-b10fa85716bb.png)
![image](https://user-images.githubusercontent.com/22816913/150955244-56b4160e-9c08-4360-aebe-842ea165f143.png)

