### PR TITLE
feat: Process orders and combinations

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -126,8 +126,8 @@ It help us to make **one** interaction, but we want to make multiple interaction
 
 - One same input for every orders but multiple outputs.
 - 1% Fee on the input.
-- The input (*source*) is from a wallet **or** a portfolio.
-- The ouput (*destination*) is the portfolio (**only**). 
+- The input (*source*) is from a wallet **or** a porfolio owned by the transactions signer.
+- The ouput (*destination*) is the portfolio owned by the transactions signer (**only**). 
 
 ```javascript
 struct BatchedInputOrders {
@@ -144,8 +144,8 @@ struct BatchedInputOrders {
 
 - Multiple inputs for every orders but one output.
 - 1% Fee on the output.
-- The input (*source*) is the portfolio (**only**). 
-- The ouput (*destination*) is from a wallet **or** a portfolio.
+- The input (*source*) is the portfolio owned by the transactions signer (**only**). 
+- The ouput (*destination*) is from a wallet **or** a portfolio owned by the transactions signer.
 
 ```javascript
 struct BatchedOutputOrders {

--- a/README.MD
+++ b/README.MD
@@ -55,9 +55,7 @@ So, we had to deal with two issues :
 Our solution is called the "**Operator**"... A new interaction is a new operator and can be added on the fly.
 They kind of work like [libraries](https://docs.soliditylang.org/en/v0.8.9/contracts.html#libraries), but since we don't want to redeploy the factory, 
 they are contracts that are called via `delegatecall` and referenced by the `OperatorResolver`.
-
 #### Operator Resolver
-
 
 An operator allows performing a precise action, like _"swap my token A for a token B"_ with a specific function, but the operator/interface will change depending on the action/context. To interact with new operators on the fly, we must expose new interfaces to the Factory.
 The `OperatorResolver` will whitelist all the Operator (`address`) with the selectors (`bytes4`) since we can't trust the caller to provide these informations.
@@ -98,6 +96,61 @@ When deploying an operator, it will also deploy the storage contract and transfe
 | FlatOperator          | Handles deposits and withdraws. No interaction with any third parties ([read more](contracts/operators/Flat/README.md)). |
 
 _More operators will be added. e.g. CurveOperator or SynthetixOperator_
+
+### Orders
+
+The `NestedFactory` is using the operators to interact with other protocols. The call from the Factory to an Operator is an "Order".
+
+An Order has several information:
+- The operator to use.
+- If it should use "Commit" or "Revert".
+- The token processed (swapped, stacked,...) by the operator (from the portfolio or wallet).
+- The commit or revert calldatas.
+
+```javascript
+struct Order {
+    bytes32 operator;
+    address token;
+    bytes callData;
+    bool commit;
+}
+```
+
+It help us to make **one** interaction, but we want to make multiple interactions. For example, to create a portfolio with multiple tokens, we need to "batch" these orders. 
+
+**There are two types of "Batched Orders" processed by the Factory to create or edit Portfolios :**
+
+#### Batched Input Orders
+![image](https://user-images.githubusercontent.com/22816913/152330910-595122d9-68ae-49dd-a058-0f16c65ce353.png)
+- One same input for every orders but multiple outputs.
+- 1% Fee on the input.
+- The input (*source*) is from a wallet **or** a portfolio.
+- The ouput (*destination*) is the portfolio (**only**). 
+
+```javascript
+struct BatchedInputOrders {
+    IERC20 inputToken;
+    uint256 amount;
+    Order[] orders;
+    bool fromReserve;
+}
+```
+
+#### Batched Output Orders
+![image](https://user-images.githubusercontent.com/22816913/152331144-8e57397f-33f6-44bb-97e5-dff87ee6fac9.png)
+- Multiple inputs for every orders but one output.
+- 1% Fee on the output.
+- The input (*source*) is the portfolio (**only**). 
+- The ouput (*destination*) is from a wallet **or** a portfolio.
+
+```javascript
+struct BatchedOutputOrders {
+    IERC20 outputToken;
+    uint256[] amounts;
+    Order[] orders;
+    bool reserved;
+}
+```
 
 ### Ownership & Governance
 Some functions of the protocol require admin rights (`onlyOwner`).

--- a/README.MD
+++ b/README.MD
@@ -102,17 +102,15 @@ _More operators will be added. e.g. CurveOperator or SynthetixOperator_
 The `NestedFactory` is using the operators to interact with other protocols. The call from the Factory to an Operator is an "Order".
 
 An Order has several information:
-- The operator to use.
-- If it should use "Commit" or "Revert".
+- The operator/selector to use
 - The token processed (swapped, stacked,...) by the operator (from the portfolio or wallet).
-- The commit or revert calldatas.
+- The calldatas.
 
 ```javascript
 struct Order {
     bytes32 operator;
     address token;
     bytes callData;
-    bool commit;
 }
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 
 <div align="center"><img width="600" src="https://user-images.githubusercontent.com/22816913/140889449-5c5afc92-0d4d-43c8-9d02-b3489eab093f.png"></div>
-
+<br/>
 <div align="center"><a href="https://nested.fi" > https://nested.fi </a></div>
 
 ## Introduction
@@ -121,7 +121,7 @@ It help us to make **one** interaction, but we want to make multiple interaction
 
 #### Batched Input Orders
 
-<div align="center"><img width="500" src="https://user-images.githubusercontent.com/22816913/152330910-595122d9-68ae-49dd-a058-0f16c65ce353.png"></div>
+<div align="center"><img width="650" src="https://user-images.githubusercontent.com/22816913/152816454-467afbf1-62a1-4d81-9cc3-e86403ab2e8f.png"></div>
 
 - One same input for every orders but multiple outputs.
 - 1% Fee on the input.
@@ -139,7 +139,7 @@ struct BatchedInputOrders {
 
 #### Batched Output Orders
 
-<div align="center"><img width="500" src="https://user-images.githubusercontent.com/22816913/152331144-8e57397f-33f6-44bb-97e5-dff87ee6fac9.png"></div>
+<div align="center"><img width="650" src="https://user-images.githubusercontent.com/22816913/152816552-f48f1a68-e8c2-44d3-b709-5f2ef17e9fb1.png"></div>
 
 - Multiple inputs for every orders but one output.
 - 1% Fee on the output.

--- a/README.MD
+++ b/README.MD
@@ -148,7 +148,7 @@ struct BatchedOutputOrders {
     IERC20 outputToken;
     uint256[] amounts;
     Order[] orders;
-    bool reserved;
+    bool toReserve;
 }
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,7 @@
-![logo](https://user-images.githubusercontent.com/22816913/140889449-5c5afc92-0d4d-43c8-9d02-b3489eab093f.png)
 
-_https://nested.fi_
+<div align="center"><img width="600" src="https://user-images.githubusercontent.com/22816913/140889449-5c5afc92-0d4d-43c8-9d02-b3489eab093f.png"></div>
+
+<div align="center"><a href="https://nested.fi" > https://nested.fi </a></div>
 
 ## Introduction
 
@@ -119,7 +120,9 @@ It help us to make **one** interaction, but we want to make multiple interaction
 **There are two types of "Batched Orders" processed by the Factory to create or edit Portfolios :**
 
 #### Batched Input Orders
-![image](https://user-images.githubusercontent.com/22816913/152330910-595122d9-68ae-49dd-a058-0f16c65ce353.png)
+
+<div align="center"><img width="500" src="https://user-images.githubusercontent.com/22816913/152330910-595122d9-68ae-49dd-a058-0f16c65ce353.png"></div>
+
 - One same input for every orders but multiple outputs.
 - 1% Fee on the input.
 - The input (*source*) is from a wallet **or** a portfolio.
@@ -135,7 +138,9 @@ struct BatchedInputOrders {
 ```
 
 #### Batched Output Orders
-![image](https://user-images.githubusercontent.com/22816913/152331144-8e57397f-33f6-44bb-97e5-dff87ee6fac9.png)
+
+<div align="center"><img width="500" src="https://user-images.githubusercontent.com/22816913/152331144-8e57397f-33f6-44bb-97e5-dff87ee6fac9.png"></div>
+
 - Multiple inputs for every orders but one output.
 - 1% Fee on the output.
 - The input (*source*) is the portfolio (**only**). 

--- a/contracts/NestedFactory.sol
+++ b/contracts/NestedFactory.sol
@@ -115,7 +115,6 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
         uint256 _originalTokenId,
         BatchedOrders calldata _batchedOrders
     ) external payable override nonReentrant {
-
         uint256 nftId = nestedAsset.mint(_msgSender(), _originalTokenId);
         (uint256 fees, IERC20 tokenSold) = _submitInOrders(nftId, _batchedOrders, true, false);
 

--- a/contracts/NestedFactory.sol
+++ b/contracts/NestedFactory.sol
@@ -93,12 +93,12 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
     function removeOperator(bytes32 operator) external override onlyOwner {
         uint256 operatorsLength = operators.length;
         for (uint256 i = 0; i < operatorsLength; i++) {
-	        if (operators[i] == operator) {
+            if (operators[i] == operator) {
                 operators[i] = operators[operatorsLength - 1];
-		        operators.pop();
+                operators.pop();
                 emit OperatorRemoved(operator);
                 return;
-	        }
+            }
         }
         revert("NF: NON_EXISTENT_OPERATOR");
     }
@@ -122,10 +122,12 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
     }
 
     /// @inheritdoc INestedFactory
-    function create(
-        uint256 _originalTokenId,
-        BatchedInputOrders[] calldata _batchedOrders
-    ) external payable override nonReentrant {
+    function create(uint256 _originalTokenId, BatchedInputOrders[] calldata _batchedOrders)
+        external
+        payable
+        override
+        nonReentrant
+    {
         uint256 nftId = nestedAsset.mint(_msgSender(), _originalTokenId);
 
         for (uint256 i = 0; i < _batchedOrders.length; i++) {
@@ -230,7 +232,7 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
         nestedRecords.deleteAsset(_nftId, _tokenIndex);
         emit NftUpdated(_nftId);
     }
-    
+
     /// @dev Internal logic extraction of processInputOrders()
     /// @param _nftId The id of the NFT to update
     /// @param _batchedOrders The order to execute
@@ -289,7 +291,12 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
         uint256 batchLength = _batchedOrders.orders.length;
         require(batchLength != 0, "NF: INVALID_ORDERS");
         uint256 _inputTokenAmount;
-        (tokenSold, _inputTokenAmount) = _transferInputTokens(_nftId, _batchedOrders.inputToken, _batchedOrders.amount, _fromReserve);
+        (tokenSold, _inputTokenAmount) = _transferInputTokens(
+            _nftId,
+            _batchedOrders.inputToken,
+            _batchedOrders.amount,
+            _fromReserve
+        );
 
         uint256 amountSpent;
         for (uint256 i = 0; i < batchLength; i++) {
@@ -312,7 +319,6 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
         // If input is from the reserve, update the records
         if (_fromReserve) {
             _decreaseHoldingAmount(_nftId, address(tokenSold), _inputTokenAmount - underSpentAmount);
-
         }
     }
 
@@ -459,9 +465,9 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
         bool _fromReserve
     ) private returns (IERC20, uint256) {
         if (address(_inputToken) == ETH) {
-            require(msg.value == _inputTokenAmount, "NF: INVALID_AMOUNT_IN");
-            weth.deposit{ value: msg.value }();
-            return (IERC20(address(weth)), msg.value);
+            require(address(this).balance >= _inputTokenAmount, "NF: INVALID_AMOUNT_IN");
+            weth.deposit{ value: _inputTokenAmount }();
+            return (IERC20(address(weth)), _inputTokenAmount);
         }
 
         uint256 balanceBefore = _inputToken.balanceOf(address(this));

--- a/contracts/NestedFactory.sol
+++ b/contracts/NestedFactory.sol
@@ -560,8 +560,7 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
     /// @param _batchedOrders The batched input orders
     function _checkMsgValue(BatchedInputOrders[] calldata _batchedOrders) private {
         uint256 ethNeeded;
-        uint256 length = _batchedOrders.length;
-        for (uint256 i = 0; i < length; i++) {
+        for (uint256 i = 0; i < _batchedOrders.length; i++) {
             if (address(_batchedOrders[i].inputToken) == ETH) {
                 ethNeeded += _batchedOrders[i].amount;
             }

--- a/contracts/NestedFactory.sol
+++ b/contracts/NestedFactory.sol
@@ -13,7 +13,7 @@ import "./NestedReserve.sol";
 import "./NestedAsset.sol";
 import "./NestedRecords.sol";
 
-/// @title Creates, updates and destroys NestedAssets.
+/// @title Creates, updates and destroys NestedAssets (portfolios).
 /// @notice Responsible for the business logic of the protocol and interaction with operators
 contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperatorResolver {
     using SafeERC20 for IERC20;
@@ -281,8 +281,8 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
     /// to submit buy orders (where the input is one asset).
     /// @param _nftId The id of the NFT impacted by the orders
     /// @param _batchedOrders The order to process
-    /// @param _toReserve True if the output is store in the reserve/records, false if not.
-    /// @param _fromReserve True if the input tokens are from the reserve
+    /// @param _toReserve True if the output is store in the reserve/records (portfolio), false if not.
+    /// @param _fromReserve True if the input tokens are from the reserve (portfolio)
     /// @return feesAmount The total amount of fees
     /// @return tokenSold The ERC20 token sold (in case of ETH to WETH)
     function _submitInOrders(
@@ -329,8 +329,8 @@ contract NestedFactory is INestedFactory, ReentrancyGuard, Ownable, MixinOperato
     /// to submit sell orders (where the output is one asset).
     /// @param _nftId The id of the NFT impacted by the orders
     /// @param _batchedOrders The order to process
-    /// @param _toReserve True if the output is store in the reserve/records, false if not.
-    /// @param _fromReserve True if the input tokens are from the reserve
+    /// @param _toReserve True if the output is store in the reserve/records (portfolio), false if not.
+    /// @param _fromReserve True if the input tokens are from the reserve (portfolio)
     /// @return feesAmount The total amount of fees
     /// @return amountBought The total amount bought
     function _submitOutOrders(

--- a/contracts/interfaces/INestedFactory.sol
+++ b/contracts/interfaces/INestedFactory.sol
@@ -52,6 +52,7 @@ interface INestedFactory {
     /// @param amount The amount to transfer (input amount)
     /// @param orders The orders to perform using the input token.
     /// @param _fromReserve Specify the input token source (true if reserve, false if wallet)
+    ///        Note: fromReserve can be read as "from portfolio"
     struct BatchedInputOrders {
         IERC20 inputToken;
         uint256 amount;
@@ -63,7 +64,8 @@ interface INestedFactory {
     /// @param outputToken The output token
     /// @param amounts The amount of sell tokens to use
     /// @param orders Orders calldata
-    /// @param toReserve Specify the output token destination (true if reserve, false if wallet)
+    /// @param toReserve Specify the output token destination (true if reserve, false if wallet)    
+    ///        Note: toReserve can be read as "to portfolio"
     struct BatchedOutputOrders {
         IERC20 outputToken;
         uint256[] amounts;

--- a/contracts/interfaces/INestedFactory.sol
+++ b/contracts/interfaces/INestedFactory.sol
@@ -63,12 +63,12 @@ interface INestedFactory {
     /// @param outputToken The output token
     /// @param amounts The amount of sell tokens to use
     /// @param orders Orders calldata
-    /// @param reserved Specify the output token destination (true if reserve, false if wallet)
+    /// @param toReserve Specify the output token destination (true if reserve, false if wallet)
     struct BatchedOutputOrders {
         IERC20 outputToken;
         uint256[] amounts;
         Order[] orders;
-        bool reserved;
+        bool toReserve;
     }
 
     /// @notice Add an operator (name) for building cache

--- a/contracts/interfaces/INestedFactory.sol
+++ b/contracts/interfaces/INestedFactory.sol
@@ -93,6 +93,11 @@ interface INestedFactory {
     /// @param _batchedOrders The order to execute
     function processInputOrders(uint256 _nftId, BatchedInputOrders[] calldata _batchedOrders) external payable;
 
+    /// @notice Process multiple output orders
+    /// @param _nftId The id of the NFT to update
+    /// @param _batchedOrders The order to execute
+    function processOutputOrders(uint256 _nftId, BatchedOutputOrders[] calldata _batchedOrders) external;
+    
     /// @notice Process multiple input orders and then withdraw (one or multiple tokens).
     /// @param _nftId The id of the NFT to update
     /// @param _batchedOrders The order to execute
@@ -112,11 +117,6 @@ interface INestedFactory {
         BatchedInputOrders[] calldata _batchedInputOrders,
         BatchedOutputOrders[] calldata _batchedOutputOrders
     ) external payable;
-
-    /// @notice Process multiple output orders
-    /// @param _nftId The id of the NFT to update
-    /// @param _batchedOrders The order to execute
-    function processOutputOrders(uint256 _nftId, BatchedOutputOrders[] calldata _batchedOrders) external;
 
     /// @notice Burn NFT and Sell all tokens for a specific ERC20 then send it back to the user
     /// @dev Will unwrap WETH output to ETH

--- a/contracts/interfaces/INestedFactory.sol
+++ b/contracts/interfaces/INestedFactory.sol
@@ -47,16 +47,28 @@ interface INestedFactory {
         bytes callData;
     }
 
-    /// @dev Represent multiple orders for a given token to perform multiple trades.
+    /// @dev Represent multiple input orders for a given token to perform multiple trades.
     /// @param inputToken The input token
     /// @param amount The amount to transfer (input amount)
     /// @param orders The orders to perform using the input token.
     /// @param _fromReserve Specify the input token source (true if reserve, false if wallet)
-    struct BatchedOrders {
+    struct BatchedInputOrders {
         IERC20 inputToken;
         uint256 amount;
         Order[] orders;
         bool fromReserve;
+    }
+
+    /// @dev Represent multiple output orders to receive a given token
+    /// @param outputToken The output token
+    /// @param amounts The amount of sell tokens to use
+    /// @param orders Orders calldata
+    /// @param reserved Specify the output token destination (true if reserve, false if wallet)
+    struct BatchedOutputOrders {
+        IERC20 outputToken;
+        uint256[] amounts;
+        Order[] orders;
+        bool reserved;
     }
 
     /// @notice Add an operator (name) for building cache
@@ -74,36 +86,17 @@ interface INestedFactory {
     /// @notice Create a portfolio and store the underlying assets from the positions
     /// @param _originalTokenId The id of the NFT replicated, 0 if not replicating
     /// @param _batchedOrders The order to execute
-    function create(uint256 _originalTokenId, BatchedOrders[] calldata _batchedOrders) external payable;
+    function create(uint256 _originalTokenId, BatchedInputOrders[] calldata _batchedOrders) external payable;
 
     /// @notice Process multiple input orders
     /// @param _nftId The id of the NFT to update
     /// @param _batchedOrders The order to execute
-    function processInputOrders(uint256 _nftId, BatchedOrders[] calldata _batchedOrders) external payable;
+    function processInputOrders(uint256 _nftId, BatchedInputOrders[] calldata _batchedOrders) external payable;
 
-    /// @notice Use one or more existing tokens from the NFT for one position.
+    /// @notice Process multiple output orders
     /// @param _nftId The id of the NFT to update
-    /// @param _buyToken The output token
-    /// @param _sellTokensAmount The amount of sell tokens to use
-    /// @param _orders Orders calldata
-    function sellTokensToNft(
-        uint256 _nftId,
-        IERC20 _buyToken,
-        uint256[] memory _sellTokensAmount,
-        Order[] calldata _orders
-    ) external;
-
-    /// @notice Liquidate one or more holdings and transfer the sale amount to the user
-    /// @param _nftId The id of the NFT to update
-    /// @param _buyToken The output token
-    /// @param _sellTokensAmount The amount of sell tokens to use
-    /// @param _orders Orders calldata
-    function sellTokensToWallet(
-        uint256 _nftId,
-        IERC20 _buyToken,
-        uint256[] memory _sellTokensAmount,
-        Order[] calldata _orders
-    ) external;
+    /// @param _batchedOrders The order to execute
+    function processOutputOrders(uint256 _nftId, BatchedOutputOrders[] calldata _batchedOrders) external;
 
     /// @notice Burn NFT and Sell all tokens for a specific ERC20 then send it back to the user
     /// @dev Will unwrap WETH output to ETH

--- a/contracts/interfaces/INestedFactory.sol
+++ b/contracts/interfaces/INestedFactory.sol
@@ -97,16 +97,6 @@ interface INestedFactory {
     /// @param _nftId The id of the NFT to update
     /// @param _batchedOrders The order to execute
     function processOutputOrders(uint256 _nftId, BatchedOutputOrders[] calldata _batchedOrders) external;
-    
-    /// @notice Process multiple input orders and then withdraw (one or multiple tokens).
-    /// @param _nftId The id of the NFT to update
-    /// @param _batchedOrders The order to execute
-    /// @param _tokenIndexes The token (indexes in records) to withdraw
-    function processInputOrdersAndWithdraw(
-        uint256 _nftId,
-        BatchedInputOrders[] calldata _batchedOrders,
-        uint256[] calldata _tokenIndexes
-    ) external payable;
 
     /// @notice Process multiple input orders and then multiple output orders
     /// @param _nftId The id of the NFT to update

--- a/contracts/interfaces/INestedFactory.sol
+++ b/contracts/interfaces/INestedFactory.sol
@@ -51,10 +51,12 @@ interface INestedFactory {
     /// @param inputToken The input token
     /// @param amount The amount to transfer (input amount)
     /// @param orders The orders to perform using the input token.
+    /// @param _fromReserve Specify the input token source (true if reserve, false if wallet)
     struct BatchedOrders {
         IERC20 inputToken;
         uint256 amount;
         Order[] orders;
+        bool fromReserve;
     }
 
     /// @notice Add an operator (name) for building cache
@@ -72,32 +74,12 @@ interface INestedFactory {
     /// @notice Create a portfolio and store the underlying assets from the positions
     /// @param _originalTokenId The id of the NFT replicated, 0 if not replicating
     /// @param _batchedOrders The order to execute
-    function create(
-        uint256 _originalTokenId,
-        BatchedOrders calldata _batchedOrders
-    ) external payable;
+    function create(uint256 _originalTokenId, BatchedOrders[] calldata _batchedOrders) external payable;
 
-    /// @notice Add or increase one position (or more) and update the NFT
+    /// @notice Process multiple input orders
     /// @param _nftId The id of the NFT to update
     /// @param _batchedOrders The order to execute
-    function addTokens(
-        uint256 _nftId,
-        BatchedOrders calldata _batchedOrders
-    ) external payable;
-
-    /// @notice Use the output token of an existing position from
-    /// the NFT for one or more positions.
-    /// @param _nftId The id of the NFT to update
-    /// @param _batchedOrders The order to execute
-    function swapTokenForTokens(
-        uint256 _nftId,
-        BatchedOrders calldata _batchedOrders
-    ) external;
-
-    /// @notice Perform multiple swaps using different input tokens and output tokens.
-    /// @param _nftId The id of the NFT to update
-    /// @param  _batchedOrders Multiple orders batched
-    function swapTokensForTokens(uint256 _nftId, BatchedOrders[] calldata _batchedOrders) external;
+    function processInputOrders(uint256 _nftId, BatchedOrders[] calldata _batchedOrders) external payable;
 
     /// @notice Use one or more existing tokens from the NFT for one position.
     /// @param _nftId The id of the NFT to update

--- a/contracts/interfaces/INestedFactory.sol
+++ b/contracts/interfaces/INestedFactory.sol
@@ -93,6 +93,26 @@ interface INestedFactory {
     /// @param _batchedOrders The order to execute
     function processInputOrders(uint256 _nftId, BatchedInputOrders[] calldata _batchedOrders) external payable;
 
+    /// @notice Process multiple input orders and then withdraw (one or multiple tokens).
+    /// @param _nftId The id of the NFT to update
+    /// @param _batchedOrders The order to execute
+    /// @param _tokenIndexes The token (indexes in records) to withdraw
+    function processInputOrdersAndWithdraw(
+        uint256 _nftId,
+        BatchedInputOrders[] calldata _batchedOrders,
+        uint256[] calldata _tokenIndexes
+    ) external payable;
+
+    /// @notice Process multiple input orders and then multiple output orders
+    /// @param _nftId The id of the NFT to update
+    /// @param _batchedInputOrders The input orders to execute (first)
+    /// @param _batchedOutputOrders The output orders to execute (after)
+    function processInputAndOutputOrders(
+        uint256 _nftId,
+        BatchedInputOrders[] calldata _batchedInputOrders,
+        BatchedOutputOrders[] calldata _batchedOutputOrders
+    ) external payable;
+
     /// @notice Process multiple output orders
     /// @param _nftId The id of the NFT to update
     /// @param _batchedOrders The order to execute

--- a/contracts/mocks/DummyRouter.sol
+++ b/contracts/mocks/DummyRouter.sol
@@ -34,26 +34,6 @@ contract DummyRouter is IERC721Receiver {
         NestedFactory(factory).destroy(nftId, IERC20(address(weth)), attackOrders);
     }
 
-    function prepareAttack(
-        address payable _factory,
-        IWETH _weth,
-        INestedFactory.Order[] calldata _tokenOrders,
-        INestedFactory.Order[] calldata _attackOrders
-    ) external payable {
-        factory = _factory;
-        weth = _weth;
-        uint256 amountIn = msg.value;
-        weth.deposit{ value: amountIn }();
-        weth.approve(_factory, amountIn);
-        attackOrders.push(_attackOrders[0]);
-        attackOrders.push(_attackOrders[1]);
-        NestedFactory(_factory).create(0, INestedFactory.BatchedOrders({
-            inputToken: IERC20(address(_weth)),
-            amount: amountIn - amountIn / 98,
-            orders: _tokenOrders
-        }));
-    }
-
     function setMaxAllowance(IERC20 _token, address _spender) external {
         ExchangeHelpers.setMaxAllowance(_token, _spender);
     }

--- a/test/unit/FlatOperator.unit.ts
+++ b/test/unit/FlatOperator.unit.ts
@@ -44,11 +44,14 @@ describe("FlatOperator", () => {
         ];
 
         await expect(
-            context.nestedFactory.connect(context.user1).create(0, {
-                inputToken: context.mockUNI.address,
-                amount: totalToSpend,
-                orders,
-            }),
+            context.nestedFactory.connect(context.user1).create(0, [
+                {
+                    inputToken: context.mockUNI.address,
+                    amount: totalToSpend,
+                    orders,
+                    fromReserve: false,
+                },
+            ]),
         ).to.revertedWith("NF: OPERATOR_CALL_FAILED");
     });
 
@@ -68,11 +71,14 @@ describe("FlatOperator", () => {
         ];
 
         await expect(
-            context.nestedFactory.connect(context.user1).create(0, {
-                inputToken: context.mockUNI.address,
-                amount: totalToSpend,
-                orders,
-            }),
+            context.nestedFactory.connect(context.user1).create(0, [
+                {
+                    inputToken: context.mockUNI.address,
+                    amount: totalToSpend,
+                    orders,
+                    fromReserve: false,
+                },
+            ]),
         ).to.revertedWith("OH: INVALID_OUTPUT_TOKEN");
     });
 
@@ -94,11 +100,14 @@ describe("FlatOperator", () => {
 
         // User1 creates the portfolio/NFT and emit event NftCreated
         await expect(
-            context.nestedFactory.connect(context.user1).create(0, {
-                inputToken: context.mockUNI.address,
-                amount: totalToSpend,
-                orders,
-            }),
+            context.nestedFactory.connect(context.user1).create(0, [
+                {
+                    inputToken: context.mockUNI.address,
+                    amount: totalToSpend,
+                    orders,
+                    fromReserve: false,
+                },
+            ]),
         )
             .to.emit(context.nestedFactory, "NftCreated")
             .withArgs(1, 0);
@@ -148,11 +157,14 @@ describe("FlatOperator", () => {
 
         // User1 creates the portfolio/NFT and emit event NftCreated
         await expect(
-            context.nestedFactory.connect(context.user1).create(0, {
-                inputToken: context.mockUNI.address,
-                amount: totalToSpend,
-                orders,
-            }),
+            context.nestedFactory.connect(context.user1).create(0, [
+                {
+                    inputToken: context.mockUNI.address,
+                    amount: totalToSpend,
+                    orders,
+                    fromReserve: false,
+                },
+            ]),
         )
             .to.emit(context.nestedFactory, "NftCreated")
             .withArgs(1, 0);

--- a/test/unit/NestedFactory.unit.ts
+++ b/test/unit/NestedFactory.unit.ts
@@ -890,7 +890,7 @@ describe("NestedFactory", () => {
         });
     });
 
-    describe("swapTokensForTokens()", () => {
+    describe("swapTokensForTokens", () => {
         // Amount already in the portfolio
         let baseUniBought = appendDecimals(6);
         let baseKncBought = appendDecimals(4);
@@ -1007,7 +1007,7 @@ describe("NestedFactory", () => {
         });
     });
 
-    describe("swapTokenForTokens()", () => {
+    describe("swapTokenForTokens", () => {
         // Amount already in the portfolio
         let baseUniBought = appendDecimals(6);
         let baseKncBought = appendDecimals(4);
@@ -1293,7 +1293,7 @@ describe("NestedFactory", () => {
         });
     });
 
-    describe("sellTokensToNft()", () => {
+    describe("sellTokensToNft", () => {
         // Amount already in the portfolio
         let baseUniBought = appendDecimals(6);
         let baseKncBought = appendDecimals(4);
@@ -1568,7 +1568,7 @@ describe("NestedFactory", () => {
     });
 
     // Tests are very similar to sellTokensToNft(), but some expectations can be different
-    describe("sellTokensToWallet()", () => {
+    describe("sellTokensToWallet", () => {
         // Amount already in the portfolio
         let baseUniBought = appendDecimals(6);
         let baseKncBought = appendDecimals(4);

--- a/test/unit/NestedFactory.unit.ts
+++ b/test/unit/NestedFactory.unit.ts
@@ -913,6 +913,7 @@ describe("NestedFactory", () => {
             let multiOrders: BatchedOrderStruct[] = [
                 {
                     inputToken: context.mockUNI.address,
+
                     amount: totalToSpendUsdc,
                     orders: getTokenBWithTokenAOrders(usdcToBuy, context.mockUNI.address, context.mockUSDC.address),
                 },

--- a/test/unit/NestedFactory.unit.ts
+++ b/test/unit/NestedFactory.unit.ts
@@ -1314,7 +1314,11 @@ describe("NestedFactory", () => {
         it("reverts if Orders list is empty", async () => {
             let orders: OrderStruct[] = [];
             await expect(
-                context.nestedFactory.connect(context.user1).sellTokensToNft(1, context.mockDAI.address, [], orders),
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockDAI.address, amounts: [], orders, reserved: true },
+                    ]),
             ).to.be.revertedWith("NF: INVALID_ORDERS");
         });
 
@@ -1342,7 +1346,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToNft(1, context.mockUSDC.address, [uniSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold], orders, reserved: true },
+                    ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
@@ -1357,7 +1363,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToNft(2, context.mockUSDC.address, [uniSold, kncSold], orders),
+                    .processOutputOrders(2, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: true },
+                    ]),
             ).to.be.revertedWith("ERC721: owner query for nonexistent token");
         });
 
@@ -1372,7 +1380,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.masterDeployer)
-                    .sellTokensToNft(1, context.mockUSDC.address, [uniSold, kncSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: true },
+                    ]),
             ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
 
@@ -1386,7 +1396,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToNft(1, context.mockUSDC.address, [uniSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold], orders, reserved: true },
+                    ]),
             ).to.be.revertedWith("NF: INPUTS_LENGTH_MUST_MATCH");
         });
 
@@ -1400,7 +1412,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToNft(1, context.mockUSDC.address, [uniSold, kncSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: true },
+                    ]),
             ).to.be.revertedWith("NF: INSUFFICIENT_AMOUNT_IN");
         });
 
@@ -1416,7 +1430,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToNft(1, context.mockUSDC.address, [uniSold, kncSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: true },
+                    ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
@@ -1432,7 +1448,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToNft(1, context.mockDAI.address, [uniSold, kncSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockDAI.address, amounts: [uniSold, kncSold], orders, reserved: true },
+                    ]),
             ).to.be.revertedWith("OH: INVALID_OUTPUT_TOKEN");
         });
 
@@ -1448,7 +1466,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToNft(1, context.mockUSDC.address, [uniSold, kncSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: true },
+                    ]),
             )
                 .to.emit(context.nestedFactory, "NftUpdated")
                 .withArgs(1);
@@ -1498,7 +1518,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToNft(1, context.mockUSDC.address, [uniSold, kncSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: true },
+                    ]),
             )
                 .to.emit(context.nestedFactory, "NftUpdated")
                 .withArgs(1);
@@ -1567,7 +1589,11 @@ describe("NestedFactory", () => {
         it("reverts if Orders list is empty", async () => {
             let orders: OrderStruct[] = [];
             await expect(
-                context.nestedFactory.connect(context.user1).sellTokensToWallet(1, context.mockDAI.address, [], orders),
+                context.nestedFactory
+                    .connect(context.user1)
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockDAI.address, amounts: [], orders, reserved: false },
+                    ]),
             ).to.be.revertedWith("NF: INVALID_ORDERS");
         });
 
@@ -1595,7 +1621,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToWallet(1, context.mockUSDC.address, [uniSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold], orders, reserved: false },
+                    ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
@@ -1610,7 +1638,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToWallet(2, context.mockUSDC.address, [uniSold, kncSold], orders),
+                    .processOutputOrders(2, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: false },
+                    ]),
             ).to.be.revertedWith("ERC721: owner query for nonexistent token");
         });
 
@@ -1625,7 +1655,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.masterDeployer)
-                    .sellTokensToWallet(1, context.mockUSDC.address, [uniSold, kncSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: false },
+                    ]),
             ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
 
@@ -1639,7 +1671,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToWallet(1, context.mockUSDC.address, [uniSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold], orders, reserved: false },
+                    ]),
             ).to.be.revertedWith("NF: INPUTS_LENGTH_MUST_MATCH");
         });
 
@@ -1653,7 +1687,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToWallet(1, context.mockUSDC.address, [uniSold, kncSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: false },
+                    ]),
             ).to.be.revertedWith("NF: INSUFFICIENT_AMOUNT_IN");
         });
 
@@ -1669,7 +1705,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToWallet(1, context.mockUSDC.address, [uniSold, kncSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: false },
+                    ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
 
@@ -1685,7 +1723,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToWallet(1, context.mockDAI.address, [uniSold, kncSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockDAI.address, amounts: [uniSold, kncSold], orders, reserved: false },
+                    ]),
             ).to.be.revertedWith("OH: INVALID_OUTPUT_TOKEN");
         });
 
@@ -1701,7 +1741,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToWallet(1, context.mockUSDC.address, [uniSold, kncSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: false },
+                    ]),
             )
                 .to.emit(context.nestedFactory, "NftUpdated")
                 .withArgs(1);
@@ -1748,7 +1790,9 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .sellTokensToWallet(1, context.mockUSDC.address, [uniSold, kncSold], orders),
+                    .processOutputOrders(1, [
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: false },
+                    ]),
             )
                 .to.emit(context.nestedFactory, "NftUpdated")
                 .withArgs(1);

--- a/test/unit/NestedFactory.unit.ts
+++ b/test/unit/NestedFactory.unit.ts
@@ -1317,7 +1317,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockDAI.address, amounts: [], orders, reserved: true },
+                        { outputToken: context.mockDAI.address, amounts: [], orders, toReserve: true },
                     ]),
             ).to.be.revertedWith("NF: INVALID_ORDERS");
         });
@@ -1347,7 +1347,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold], orders, reserved: true },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold], orders, toReserve: true },
                     ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
@@ -1364,7 +1364,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(2, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: true },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: true },
                     ]),
             ).to.be.revertedWith("ERC721: owner query for nonexistent token");
         });
@@ -1381,7 +1381,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.masterDeployer)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: true },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: true },
                     ]),
             ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
@@ -1397,7 +1397,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold], orders, reserved: true },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold], orders, toReserve: true },
                     ]),
             ).to.be.revertedWith("NF: INPUTS_LENGTH_MUST_MATCH");
         });
@@ -1413,7 +1413,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: true },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: true },
                     ]),
             ).to.be.revertedWith("NF: INSUFFICIENT_AMOUNT_IN");
         });
@@ -1431,7 +1431,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: true },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: true },
                     ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
@@ -1449,7 +1449,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockDAI.address, amounts: [uniSold, kncSold], orders, reserved: true },
+                        { outputToken: context.mockDAI.address, amounts: [uniSold, kncSold], orders, toReserve: true },
                     ]),
             ).to.be.revertedWith("OH: INVALID_OUTPUT_TOKEN");
         });
@@ -1467,7 +1467,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: true },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: true },
                     ]),
             )
                 .to.emit(context.nestedFactory, "NftUpdated")
@@ -1519,7 +1519,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: true },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: true },
                     ]),
             )
                 .to.emit(context.nestedFactory, "NftUpdated")
@@ -1592,7 +1592,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockDAI.address, amounts: [], orders, reserved: false },
+                        { outputToken: context.mockDAI.address, amounts: [], orders, toReserve: false },
                     ]),
             ).to.be.revertedWith("NF: INVALID_ORDERS");
         });
@@ -1622,7 +1622,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold], orders, reserved: false },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold], orders, toReserve: false },
                     ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
@@ -1639,7 +1639,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(2, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: false },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: false },
                     ]),
             ).to.be.revertedWith("ERC721: owner query for nonexistent token");
         });
@@ -1656,7 +1656,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.masterDeployer)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: false },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: false },
                     ]),
             ).to.be.revertedWith("NF: CALLER_NOT_OWNER");
         });
@@ -1672,7 +1672,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold], orders, reserved: false },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold], orders, toReserve: false },
                     ]),
             ).to.be.revertedWith("NF: INPUTS_LENGTH_MUST_MATCH");
         });
@@ -1688,7 +1688,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: false },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: false },
                     ]),
             ).to.be.revertedWith("NF: INSUFFICIENT_AMOUNT_IN");
         });
@@ -1706,7 +1706,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: false },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: false },
                     ]),
             ).to.be.revertedWith("NF: OPERATOR_CALL_FAILED");
         });
@@ -1724,7 +1724,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockDAI.address, amounts: [uniSold, kncSold], orders, reserved: false },
+                        { outputToken: context.mockDAI.address, amounts: [uniSold, kncSold], orders, toReserve: false },
                     ]),
             ).to.be.revertedWith("OH: INVALID_OUTPUT_TOKEN");
         });
@@ -1742,7 +1742,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: false },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: false },
                     ]),
             )
                 .to.emit(context.nestedFactory, "NftUpdated")
@@ -1791,7 +1791,7 @@ describe("NestedFactory", () => {
                 context.nestedFactory
                     .connect(context.user1)
                     .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, reserved: false },
+                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: false },
                     ]),
             )
                 .to.emit(context.nestedFactory, "NftUpdated")

--- a/test/unit/NestedFactory.unit.ts
+++ b/test/unit/NestedFactory.unit.ts
@@ -171,9 +171,7 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .create(0, [
-                        { inputToken: context.mockDAI.address, amount: appendDecimals(5), orders, fromReserve: false },
-                    ]),
+                    .create(0, [{inputToken: context.mockDAI.address, amount:appendDecimals(5), orders, fromReserve: false}]),
             ).to.be.revertedWith("MOR: MISSING_OPERATOR: test");
 
             await context.nestedFactory
@@ -422,11 +420,7 @@ describe("NestedFactory", () => {
 
             // User1 creates the portfolio/NFT and emit event NftCreated
             await expect(
-                context.nestedFactory
-                    .connect(context.user1)
-                    .create(0, [
-                        { inputToken: context.mockDAI.address, amount: totalToSpend, orders, fromReserve: false },
-                    ]),
+                context.nestedFactory.connect(context.user1).create(0, [{inputToken: context.mockDAI.address, amount:totalToSpend, orders, fromReserve: false}]),
             )
                 .to.emit(context.nestedFactory, "NftCreated")
                 .withArgs(1, 0);
@@ -465,25 +459,16 @@ describe("NestedFactory", () => {
 
             // User1 creates the portfolio/NFT and emit event NftCreated (not more than needed)
             await expect(
-                context.nestedFactory.connect(context.user1).create(0, [
-                    {
-                        inputToken: context.mockDAI.address,
-                        amount: appendDecimals(10).add(getExpectedFees(totalToBought)),
-                        orders,
-                        fromReserve: false,
-                    },
-                ]),
+                context.nestedFactory
+                    .connect(context.user1)
+                    .create(0, [{inputToken: context.mockDAI.address, amount: appendDecimals(10).add(getExpectedFees(totalToBought)), orders, fromReserve: false}]),
             )
                 .to.emit(context.nestedFactory, "NftCreated")
                 .withArgs(1, 0);
 
             // User1 replicates the portfolio/NFT and emit event NftCreated (with the same amounts)
             await expect(
-                context.nestedFactory
-                    .connect(context.user1)
-                    .create(1, [
-                        { inputToken: context.mockDAI.address, amount: totalToSpend, orders, fromReserve: false },
-                    ]),
+                context.nestedFactory.connect(context.user1).create(1, [{inputToken: context.mockDAI.address, amount:totalToSpend, orders, fromReserve: false}]),
             )
                 .to.emit(context.nestedFactory, "NftCreated")
                 .withArgs(2, 1);
@@ -819,9 +804,7 @@ describe("NestedFactory", () => {
 
             await context.nestedFactory
                 .connect(context.user1)
-                .processInputOrders(1, [
-                    { inputToken: context.mockDAI.address, amount: totalToSpend, orders, fromReserve: false },
-                ]);
+                .processInputOrders(1, [{inputToken: context.mockDAI.address, amount: totalToSpend, orders, fromReserve: false}]);
 
             // The user must receive the DAI in excess
             expect(await context.mockDAI.balanceOf(context.user1.address)).to.be.equal(
@@ -890,7 +873,7 @@ describe("NestedFactory", () => {
         });
     });
 
-    describe("swapTokensForTokens", () => {
+    describe("Multiswap", () => {
         // Amount already in the portfolio
         let baseUniBought = appendDecimals(6);
         let baseKncBought = appendDecimals(4);
@@ -1004,6 +987,10 @@ describe("NestedFactory", () => {
 
             const holdingsDAIAmount = await context.nestedRecords.getAssetHolding(1, context.mockDAI.address);
             expect(holdingsDAIAmount).to.be.equal(daiToBuy);
+        });
+
+        it("Input Orders and Output Orders (Add ETH and exchange everything else for USDC) ", async () => {
+                
         });
     });
 
@@ -1215,40 +1202,38 @@ describe("NestedFactory", () => {
              * - Buy 3 UNI with 3 KNC from the portfolio
              * - The user needs 3 KNC (+ fees) but will spend 4 KNC
              */
-            const uniBought = appendDecimals(3);
-            const totalToSpend = appendDecimals(4);
-
-            // Orders for UNI and KNC
-            let orders: OrderStruct[] = getTokenBWithTokenAOrders(
-                uniBought,
-                context.mockKNC.address,
-                context.mockUNI.address,
-            );
-
-            // User1 updates the portfolio/NFT and emit event NftUpdated
-            await expect(
-                context.nestedFactory
-                    .connect(context.user1)
-                    .processInputOrders(1, [
-                        { inputToken: context.mockKNC.address, amount: totalToSpend, orders, fromReserve: true },
-                    ]),
-            )
-                .to.emit(context.nestedFactory, "NftUpdated")
-                .withArgs(1);
-
-            // The user must receive the KNC in excess (inside the portfolio)
-            expect(await context.mockKNC.balanceOf(context.nestedReserve.address)).to.be.equal(
-                totalToSpend.sub(uniBought).sub(uniBought.div(100)),
-            );
-
-            const totalWeigths = await context.feeSplitter.totalWeights();
-            const royaltiesWeight = await context.feeSplitter.royaltiesWeight();
-            expect(
-                await context.feeSplitter.getAmountDue(context.shareholder1.address, context.mockKNC.address),
-            ).to.equal(uniBought.div(100).mul(1000).div(totalWeigths.sub(royaltiesWeight)));
-            expect(
-                await context.feeSplitter.getAmountDue(context.shareholder2.address, context.mockKNC.address),
-            ).to.equal(uniBought.div(100).mul(1700).div(totalWeigths.sub(royaltiesWeight)));
+             const uniBought = appendDecimals(3);
+             const totalToSpend = appendDecimals(4);
+ 
+             // Orders for UNI and KNC
+             let orders: OrderStruct[] = getTokenBWithTokenAOrders(
+                 uniBought,
+                 context.mockKNC.address,
+                 context.mockUNI.address,
+             );
+ 
+             // User1 updates the portfolio/NFT and emit event NftUpdated
+             await expect(
+                 context.nestedFactory
+                     .connect(context.user1)
+                     .processInputOrders(1, [{inputToken: context.mockKNC.address, amount: totalToSpend, orders, fromReserve: true}]),
+             )
+                 .to.emit(context.nestedFactory, "NftUpdated")
+                 .withArgs(1);
+ 
+             // The user must receive the KNC in excess (inside the portfolio)
+             expect(await context.mockKNC.balanceOf(context.nestedReserve.address)).to.be.equal(
+                 totalToSpend.sub(uniBought).sub(uniBought.div(100)),
+             );
+ 
+             const totalWeigths = await context.feeSplitter.totalWeights();
+             const royaltiesWeight = await context.feeSplitter.royaltiesWeight();
+             expect(
+                 await context.feeSplitter.getAmountDue(context.shareholder1.address, context.mockKNC.address),
+             ).to.equal(uniBought.div(100).mul(1000).div(totalWeigths.sub(royaltiesWeight)));
+             expect(
+                 await context.feeSplitter.getAmountDue(context.shareholder2.address, context.mockKNC.address),
+             ).to.equal(uniBought.div(100).mul(1700).div(totalWeigths.sub(royaltiesWeight)));
         });
 
         it("swap UNI in portfolio for USDC (ZeroExOperator) with right amounts", async () => {
@@ -1518,9 +1503,7 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: true },
-                    ]),
+                    .processOutputOrders(1, [{outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: true}]),
             )
                 .to.emit(context.nestedFactory, "NftUpdated")
                 .withArgs(1);
@@ -1790,9 +1773,7 @@ describe("NestedFactory", () => {
             await expect(
                 context.nestedFactory
                     .connect(context.user1)
-                    .processOutputOrders(1, [
-                        { outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: false },
-                    ]),
+                    .processOutputOrders(1, [{outputToken: context.mockUSDC.address, amounts: [uniSold, kncSold], orders, toReserve: false}]),
             )
                 .to.emit(context.nestedFactory, "NftUpdated")
                 .withArgs(1);

--- a/test/unit/NestedFactory.unit.ts
+++ b/test/unit/NestedFactory.unit.ts
@@ -913,7 +913,6 @@ describe("NestedFactory", () => {
             let multiOrders: BatchedOrderStruct[] = [
                 {
                     inputToken: context.mockUNI.address,
-
                     amount: totalToSpendUsdc,
                     orders: getTokenBWithTokenAOrders(usdcToBuy, context.mockUNI.address, context.mockUSDC.address),
                 },

--- a/test/unit/NestedFactory.unit.ts
+++ b/test/unit/NestedFactory.unit.ts
@@ -360,6 +360,29 @@ describe("NestedFactory", () => {
             ).to.be.reverted;
         });
 
+        it("the ETH amount is more than total sum of ETH in orders", async () => {
+            /*
+             * All the amounts for this test :
+             * - Buy 6 UNI and 4 KNC
+             * - The user needs 10 ETH (+ fees), will specify 11 ETH, but will send 12 ETH (msg.value)
+             */
+            const uniBought = appendDecimals(6);
+            const kncBought = appendDecimals(4);
+            const totalToSpend = appendDecimals(11);
+
+            // Orders for UNI and KNC
+            let orders: OrderStruct[] = getUniAndKncWithETHOrders(uniBought, kncBought);
+
+            // Should revert with "assert" (no message)
+            await expect(
+                context.nestedFactory
+                    .connect(context.user1)
+                    .create(0, [{ inputToken: ETH, amount: totalToSpend, orders, fromReserve: false }], {
+                        value: totalToSpend.add(appendDecimals(1)),
+                    }),
+            ).to.be.revertedWith("NF: WRONG_MSG_VALUE");
+        });
+
         it("Creates NFT from DAI with KNI and UNI inside (ZeroExOperator) with right amounts", async () => {
             // All the amounts for this test
             const uniBought = appendDecimals(6);


### PR DESCRIPTION
We are now introducing Batched**Input**Orders and Batched**Output**Orders, to extend the possibilities beyond the multi-swap (without allowing everything) and simplify the interface.

#### Batched Input Orders
![image](https://user-images.githubusercontent.com/22816913/152330910-595122d9-68ae-49dd-a058-0f16c65ce353.png)
- One same input for every orders but multiple outputs.
- 1% Fee on the input.
- The input (*source*) is from a wallet **or** a portfolio.
- The ouput (*destination*) is the portfolio (**only**). 

```javascript
struct BatchedInputOrders {
    IERC20 inputToken;
    uint256 amount;
    Order[] orders;
    bool fromReserve;
}
```

#### Batched Output Orders
![image](https://user-images.githubusercontent.com/22816913/152331144-8e57397f-33f6-44bb-97e5-dff87ee6fac9.png)
- Multiple inputs for every orders but one output.
- 1% Fee on the output.
- The input (*source*) is the portfolio (**only**). 
- The output (*destination*) is from a wallet **or** a portfolio.

```javascript
struct BatchedOutputOrders {
    IERC20 outputToken;
    uint256[] amounts;
    Order[] orders;
    bool toReserve;
}
```

We removed multiple functions: 
- `addTokens`
- `swapTokenForTokens `
- `swapTokensForTokens`
- `sellTokensToNft`

And added new ones : 

```javascript
/// @notice Create a portfolio and store the underlying assets from the positions
/// @param _originalTokenId The id of the NFT replicated, 0 if not replicating
/// @param _batchedOrders The order to execute
function create(uint256 _originalTokenId, BatchedInputOrders[] calldata _batchedOrders) external payable;

/// @notice Process multiple input orders
/// @param _nftId The id of the NFT to update
/// @param _batchedOrders The order to execute
function processInputOrders(uint256 _nftId, BatchedInputOrders[] calldata _batchedOrders) external payable;

/// @notice Process multiple output orders
/// @param _nftId The id of the NFT to update
/// @param _batchedOrders The order to execute
function processOutputOrders(uint256 _nftId, BatchedOutputOrders[] calldata _batchedOrders) external;

/// @notice Process multiple input orders and then multiple output orders
/// @param _nftId The id of the NFT to update
/// @param _batchedInputOrders The input orders to execute (first)
/// @param _batchedOutputOrders The output orders to execute (after)
function processInputAndOutputOrders(
    uint256 _nftId,
    BatchedInputOrders[] calldata _batchedInputOrders,
    BatchedOutputOrders[] calldata _batchedOutputOrders
) external payable;
```

_Note : The `create` function is not new, but is now allowing to make multiple `BatchedInputOrders`._

### New transfer input tokens ⚠️

Now that we can make multiple `BatchedInputOrders`, we can use ETH as `inputToken` multiple times.
The `_transferInputTokens` function was using `msg.value` to `deposit` in the WETH contract and check if the `msg.value` amount was valid. Therefore, this way of handling ETH will fail if we make more than one `BatchedInputOrders`.

To handle this case : 
```javascript
if (address(_inputToken) == ETH) {
    require(address(this).balance >= _inputTokenAmount, "NF: INVALID_AMOUNT_IN");
    weth.deposit{ value: _inputTokenAmount }();
    return (IERC20(address(weth)), _inputTokenAmount);
}
```

The function will check if the balance of ETH is enough to deposit the `_inputTokenAmount` and will `deposit` this amount. We are consuming the ETH balance for each input orders.
But there is a downside, a user can send more ETH than the sum of `BatchedInputOrders.amount` (in case of an error in the front-end implementation). And someone could create/edit a portfolio with the `NestedFactory` Ethers , because we are not checking `msg.value`.

To avoid this issue, we need to check the `msg.value` with this function:
```javascript
/// @dev Verify that msg.value is equal to the amount needed (in the orders)
/// @param _batchedOrders The batched input orders
function _checkMsgValue(BatchedInputOrders[] calldata _batchedOrders) private {
    uint256 ethNeeded;
    uint256 length = _batchedOrders.length;
    for (uint256 i = 0; i < length; i++) {
        if (address(_batchedOrders[i].inputToken) == ETH) {
            ethNeeded += _batchedOrders[i].amount;
        }
    }
    require(msg.value == ethNeeded, "NF: WRONG_MSG_VALUE"); 
}
```
This function is called at the beginning of every payable functions, to check `msg.value`.

